### PR TITLE
Redo PR #23 to address the underlying issue 'buffer overflow detected' on some systems

### DIFF
--- a/src/graphviz/lib/dotgen/rank.c
+++ b/src/graphviz/lib/dotgen/rank.c
@@ -59,20 +59,19 @@ cleanup1(graph_t * g)
 	     * handle it a second time. For example, parallel multiedges 
 	     * share a virtual edge.
 	     */
-	    if (f && (e == ED_to_orig(f))) {
-		edge_t *e1, *f1;
-		for (e1 = agfstout(g, n); e1; e1 = agnxtout(g, e1)) {
-		    if (e != e1) {
-			f1 = ED_to_virt(e1);
-			if (f1 && (f == f1)) {
-			    ED_to_virt(e1) = NULL;
-			}
-		    }
-		}
-		free(f);
-	    }
-	    ED_to_virt(e) = NULL;
-	}
+	    if (f && (e != ED_to_orig(f))) {
+                ED_to_virt(e) = NULL;
+            }
+        }
+    }
+    for (n = agfstnode(g); n; n = agnxtnode(g, n)) {
+        for (e = agfstout(g, n); e; e = agnxtout(g, e)) {
+            f = ED_to_virt(e);
+            if (f && ED_to_orig(f) == e) {
+                free(f);
+                ED_to_virt(e) = NULL;
+            }
+        }
     }
     free(GD_comp(g).list);
     GD_comp(g).list = NULL;

--- a/vignettes/Rgraphviz.Rnw
+++ b/vignettes/Rgraphviz.Rnw
@@ -698,16 +698,13 @@ sgL = list(list(graph=sg1, cluster = FALSE, attrs = c(rank="sink")))
 att = list(graph = list(rankdir = "LR", rank = ""))
 @
 %
-Finally, in Figure~\ref{figbipartite} we plot the bipartite graph, but blocked for Bioc 3.21 release.
-% triggers ==57148==ERROR: AddressSanitizer: heap-use-after-free on address 0x51200052d080 at pc 0x7ffff2764317 
-%bp 0x7ffffffc21a0 sp 0x7ffffffc2198
-%READ of size 8 at 0x51200052d080 thread T0
-%    #0 0x7ffff2764316 in cleanup1 /tmp/RtmpRFNn5A/R.INSTALLab7116d71997/Rgraphviz/src/graphviz/lib/dotgen/rank.c:62:21
-<<figbipartite, fig=TRUE, include=FALSE, prefix=FALSE, width=4.5, eval=FALSE>>=
+Finally, in Figure~\ref{figbipartite} we plot the bipartite graph.
+%
+<<figbipartite, fig=TRUE, include=FALSE, prefix=FALSE, width=4.5>>=
 plot(g, attrs = att, nodeAttrs=nA, subGList = sgL)
 @
 %
-%\inclfig{figbipartite}{0.4\textwidth}{A bipartite graph.}
+\inclfig{figbipartite}{0.4\textwidth}{A bipartite graph.}
 
 %--------------------------------------------------
 \section{NEW Another workflow to plot a graph }


### PR DESCRIPTION
Redo PR #23 to re-enable vignette code triggering buffer overflow, then update underlying C code to follow code in the current (changed but still close enough) graphviz C library [rank.c](https://gitlab.com/graphviz/graphviz/-/blob/ee78e077ce5fcc7ec6f3b2a81a002333e3453ef2/lib/dotgen/rank.c#L47-84).

The vignette now builds and installs under UBSAN, provided (unrelated) memory leak reporting is disabled.

```sh
ASAN_OPTIONS=detect_leaks=0 RD CMD build Rgraphviz
ASAN_OPTIONS=detect_leaks=0 RD CMD INSTALL Rgraphviz_2.51.7.tar.gz
```

The problem vignette now builds successfully, e.g.,

```sh
RD CMD Stangle Rgraphviz/vignettes/Rgraphviz.Rnw
ASAN_OPTIONS=detect_leaks=0 RD -f Rgraphviz.R
```

(other unrelated sanitizer issues are flagged)

Unrelated Memory leaks are still present, as seen in the long output of

```sh
RD -f Rgraphviz.R
...
SUMMARY: AddressSanitizer: 518494 byte(s) leaked in 33066 allocation(s).
```