### PR TITLE
Avoid memory leaks in R package code

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,3 +23,8 @@
     })
     .Call("Rgraphviz_init", PACKAGE = "Rgraphviz")
 }
+
+.onUnload <- function(libpath) {
+    message(".onUnload()")
+    .Call("Rgraphviz_unload", PACKAGE = "Rgraphviz");
+}

--- a/src/Rgraphviz.c
+++ b/src/Rgraphviz.c
@@ -82,7 +82,7 @@ int getVectorPos(SEXP vector, const char *str) {
     return(i);
 }
 
-SEXP Rgraphviz_fin(SEXP s) {
+void Rgraphviz_fin(SEXP s) {
     /* Finalizer for the external reference */
     Agraph_t *g;
 
@@ -90,7 +90,6 @@ SEXP Rgraphviz_fin(SEXP s) {
     g = R_ExternalPtrAddr(s);
     agclose(g);
     R_ClearExternalPtr(s);
-    return(R_NilValue);
 }
 
 SEXP assignAttrs(SEXP attrList, SEXP objList,

--- a/src/buildEdgeList.c
+++ b/src/buildEdgeList.c
@@ -126,6 +126,7 @@ SEXP Rgraphviz_buildEdgeList(SEXP edgeL, SEXP edgeMode, SEXP subGList,
                     UNPROTECT(3);
 
                 }
+                free(edgeName);
                 UNPROTECT(1);
                 continue;
             }

--- a/src/graphviz/lib/gvc/gvplugin.c
+++ b/src/graphviz/lib/gvc/gvplugin.c
@@ -464,8 +464,10 @@ char **gvPluginList(GVC_t * gvc, char* kind, int* sz, const char *str)
 	if (!typestr_last || strcasecmp(typestr_last, q) != 0) {
 	    list = RALLOC(cnt+1,list,char*);
 	    list[cnt++] = q;
-	}
-	typestr_last = q;
+            typestr_last = q;
+	} else {
+            free(q);
+        }
     }
 
     *sz = cnt;

--- a/src/graphvizVersion.c
+++ b/src/graphvizVersion.c
@@ -20,46 +20,56 @@ SEXP Rgraphviz_capabilities(void) {
     PROTECT(capabilities_layout = NEW_CHARACTER(count));
     for (cc = 0; cc < count; cc++) {
 	SET_STRING_ELT(capabilities_layout, cc, mkChar(lp[cc]));
+        free(lp[cc]);
     }
     SET_VECTOR_ELT(capabilities, 0, capabilities_layout);
     SET_STRING_ELT(names, 0, mkChar("layoutTypes"));
     UNPROTECT(1);
+    free(lp);
     
     lp = gvPluginList(gvc, "render", &count, NULL);
     PROTECT(capabilities_render = NEW_CHARACTER(count));
     for (cc = 0; cc < count; cc++) {
 	SET_STRING_ELT(capabilities_render, cc, mkChar(lp[cc]));
+        free(lp[cc]);
     }
     SET_VECTOR_ELT(capabilities, 1, capabilities_render);
     SET_STRING_ELT(names, 1, mkChar("renderTypes"));
     UNPROTECT(1);
+    free(lp);
 
     lp = gvPluginList(gvc, "textlayout", &count, NULL);
     PROTECT(capabilities_textlayout = NEW_CHARACTER(count));
     for (cc = 0; cc < count; cc++) {
 	SET_STRING_ELT(capabilities_textlayout, cc, mkChar(lp[cc]));
+        free(lp[cc]);
     }
     SET_VECTOR_ELT(capabilities, 2, capabilities_textlayout);
     SET_STRING_ELT(names, 2, mkChar("textlayoutTypes"));
     UNPROTECT(1);
-    
+    free(lp);
+
     lp = gvPluginList(gvc, "device", &count, NULL);
     PROTECT(capabilities_device = NEW_CHARACTER(count));
     for (cc = 0; cc < count; cc++) {
 	SET_STRING_ELT(capabilities_device, cc, mkChar(lp[cc]));
+        free(lp[cc]);
     }
     SET_VECTOR_ELT(capabilities, 3, capabilities_device);
     SET_STRING_ELT(names, 3, mkChar("deviceTypes"));
     UNPROTECT(1);
+    free(lp);
 
     lp = gvPluginList(gvc, "loadimage", &count, NULL);
     PROTECT(capabilities_loadimage = NEW_CHARACTER(count));
     for (cc = 0; cc < count; cc++) {
 	SET_STRING_ELT(capabilities_loadimage, cc, mkChar(lp[cc]));
+        free(lp[cc]);
     }
     SET_VECTOR_ELT(capabilities, 4, capabilities_loadimage);
     SET_STRING_ELT(names, 4, mkChar("loadimageTypes"));
     UNPROTECT(1);
+    free(lp);
 
     setAttrib(capabilities, R_NamesSymbol, names);
     UNPROTECT(2);

--- a/src/init.c
+++ b/src/init.c
@@ -32,3 +32,8 @@ SEXP Rgraphviz_init(void) {
 #endif
     return(R_NilValue);
 }
+
+SEXP Rgraphviz_unload(void) {
+    if ( gvc ) { gvFreeContext(gvc); gvc = NULL; }
+    return(R_NilValue);
+}


### PR DESCRIPTION
These changes address easily solved leaks in the R package code, as detailed in the commit messages. Additional more complicated leaks in the R package code (relating to management of graphs during `doLayout()` for neato and other layouts) and in the graphviz library are not addressed.

Many of the compiler warnings (none introduced by changes here) during `R CMD check` are easily addressed, but involve changes to the graphviz library code and so were not addressed.